### PR TITLE
Align menu text to center

### DIFF
--- a/lib/popup_menu.dart
+++ b/lib/popup_menu.dart
@@ -462,6 +462,7 @@ class _MenuItemWidgetState extends State<_MenuItemWidget> {
               child: Text(
                 widget.item.menuTitle,
                 style: widget.item.menuTextStyle,
+                textAlign: TextAlign.center,
               ),
             ),
           )


### PR DESCRIPTION
Aligning the menu text to the center for better aesthetics. 